### PR TITLE
메뉴바 완성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,11 +3,13 @@ import Menubar from './components/Menubar';
 import Home from './components/Home';
 import CheckTask from './components/Check_task';
 import CheckAttend from './components/Check_attend';
+import CheckMenubar from './components/Check_menubar';
 import Mypage from './components/Mypage';
 import StudyMain from './components/Study_main';
 import Login from './components/Login';
 import Signup from './components/Signup';
 import SubmitTask from './components/Submit_task';
+
 import { Routes, Route } from 'react-router-dom';
 
 const App = () => {
@@ -16,8 +18,11 @@ const App = () => {
       <Routes>
         <Route path="/" element={<Menubar />}>
           <Route index element={<Home />} />
-          <Route path="/check_task" element={<CheckTask />}></Route>
-          <Route path="/check_attend" element={<CheckAttend />}></Route>
+          {/* 태영 : 과제체크 페이지와 출석 체크 페이지 묶음 */}
+          <Route path="/checks" element={<CheckMenubar />}>
+            <Route index element={<CheckTask />} />
+            <Route path="attend" element={<CheckAttend />}></Route>
+          </Route>
           <Route path="/mypage" element={<Mypage />}></Route>
           <Route path="/study_main" element={<StudyMain />}></Route>
           {/* 은 과제제출 페이지 라우터 설정 */}

--- a/src/components/Check_attend.js
+++ b/src/components/Check_attend.js
@@ -3,19 +3,12 @@
 import React from 'react';
 import '../css/ResetCSS.css';
 import styles from '../css/Check_attend.module.css';
-import { Link } from 'react-router-dom';
+// import { Link } from 'react-router-dom';
+// import CheckMenubar from './Check_menubar';
 
 const Check_task = () => {
   return (
     <div className={styles.chkbox}>
-      <div className={styles.chkheader}>
-        <Link to="/check_task" style={{ textDecoration: 'none' }}>
-          <p className={styles.tasks}>과제 체크</p>
-        </Link>
-        <Link to="/check_attend" style={{ textDecoration: 'none' }}>
-          <p className={styles.attends}>출석 체크</p>
-        </Link>
-      </div>
       <p className={styles.chktitle}> 이번주 세션 공지 </p>
       <hr className={styles.divider} />
       <img

--- a/src/components/Check_menubar.js
+++ b/src/components/Check_menubar.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from '../css/Check_attend.module.css';
+import { Link, Outlet, NavLink } from 'react-router-dom';
+
+const Check_menubar = () => {
+  return (
+    <div className={styles.chkbox}>
+      <div className={styles.chkheader}>
+        <NavLink to="/checks" style={{ textDecoration: 'none' }}>
+          <p className={styles.tasks}>과제 체크</p>
+        </NavLink>
+        <NavLink to="/checks/attend" style={{ textDecoration: 'none' }}>
+          <p className={styles.attends}>출석 체크</p>
+        </NavLink>
+      </div>
+      <Outlet />
+    </div>
+  );
+};
+
+export default Check_menubar;

--- a/src/components/Check_task.js
+++ b/src/components/Check_task.js
@@ -3,19 +3,12 @@
 import React from 'react';
 import '../css/ResetCSS.css';
 import styles from '../css/Check_task.module.css';
-import { Link } from 'react-router-dom';
+// import { Link } from 'react-router-dom';
+// import CheckMenubar from './Check_menubar';
 
 const Check_task = () => {
   return (
     <div className={styles.chkbox}>
-      <div className={styles.chkheader}>
-        <Link to="/check_task" style={{ textDecoration: 'none' }}>
-          <p className={styles.tasks}>과제 체크</p>
-        </Link>
-        <Link to="/check_attend" style={{ textDecoration: 'none' }}>
-          <p className={styles.attends}>출석 체크</p>
-        </Link>
-      </div>
       <p className={styles.chktitle}> 이번주 제출 과제 공지 ( ~ 3/23 ) </p>
       <hr className={styles.divider} />
       <img

--- a/src/components/Menubar.js
+++ b/src/components/Menubar.js
@@ -39,7 +39,7 @@ const Menubar = () => {
           </li>
           <li>
             <NavLink
-              to="{슈라랄라랄}"
+              to="/checks"
               className={styles.checkLi}
               style={({ isActive }) => ({
                 backgroundImage: isActive ? `url(${activeCheck})` : '',
@@ -78,11 +78,7 @@ const Menubar = () => {
               </NavLink>
             </li>
             <li id="check_text">
-              <NavLink
-                style={Active}
-                className={styles.clicked}
-                to="/check_task"
-              >
+              <NavLink style={Active} className={styles.clicked} to="/checks">
                 체크
               </NavLink>
             </li>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4732,11 +4732,6 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
-"fsevents@^2.3.2", "fsevents@~2.3.2":
-  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  "version" "2.3.2"
-
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"


### PR DESCRIPTION
*은빈님 필독*
출석, 과제 체크 메뉴바를 묶는 새로운 라우터를 만들었습니다.
![image](https://user-images.githubusercontent.com/49816869/153716931-bdaa1bd2-34f1-46ea-8cb9-cbbf1cf774bb.png)
보시는것처럼 기존 과제 체크는 /checks, 출석 체크는 /checks/attend 경로로 지정되어있습니다.

기존 Check_attned.js와 Check_task.js에 있던 menubar 영역을 Check_menubar.js 라는 새로운 컴포넌트를 생성하여 분리하였습니다.( 체크들을 묶기 위함.)
자세한 CSS까지 제가 건들면 혼란이 생길것 같아 분리 및 경로설정만 한 상태입니다! 

+ 이슈 
![image](https://user-images.githubusercontent.com/49816869/153717024-99294c83-5acb-4e0d-96f3-e601011de7d4.png)
분류만 한 상태인데 위와 같이 attend영역에서 스피커 아이콘이 경로를 찾아가지 못하는 문제가 발생하였습니다! attend와 task의 css 파일이 분리되어있던데 관련 문제인 것 같습니다!

check_menubar css와 attned, task css 확인 및 분리시켜주시면 감사하겠습니다!


